### PR TITLE
Invoke rsync using sudo

### DIFF
--- a/src/service-guides/bitcoin/blockchain-migration.md
+++ b/src/service-guides/bitcoin/blockchain-migration.md
@@ -58,7 +58,7 @@ This is an advanced feature and should be used with caution. Start9 is not respo
     ```
 
     ```
-    rsync -e "ssh -i ~/.ssh/temp.key" -povgr --append-verify --rsync-path="sudo mkdir -p /embassy-data/package-data/volumes/bitcoind/data/main ; sudo rsync" ./{blocks,chainstate} start9@unsynced.local:/embassy-data/package-data/volumes/bitcoind/data/main/
+    sudo rsync -e "ssh -i ~/.ssh/temp.key" -povgr --append-verify --rsync-path="sudo mkdir -p /embassy-data/package-data/volumes/bitcoind/data/main ; sudo rsync" ./{blocks,chainstate} start9@unsynced.local:/embassy-data/package-data/volumes/bitcoind/data/main/
     ```
 
 1.  Wait some hours until the copy is complete. On a gigabit network, the limiting factor will be the write speed of your SSD on the unsynced server.


### PR DESCRIPTION
This sudo is not necessary, unless the user is trying to invoke the command as an unprivileged user.  This wouldn't happen if they're working through the guide exactly in sequence, but if the transfer is interrupted and they just ssh back in, they may forget to perform the sudo command in the previous steps, so this will be necessary.  It was already confusing for at least [one user](https://github.com/Start9Labs/documentation/issues/646), and there's no harm in adding it.   While not necessarily necessary (😉) it won't hurt even if the user is already root, and it's required for it to work if they aren't.