### PR TITLE
Fix broken Exver link in flavors.md

### DIFF
--- a/start-os/src/flavors.md
+++ b/start-os/src/flavors.md
@@ -4,7 +4,7 @@ Flavors are different services that share the same package ID. They are differen
 
 ## Version Format
 
-Flavor versions are designated by their exver prefix: `#flavor:upstream-semver:downstream-semver`. For more details on version formatting, see [Exver](/packaging/src/exver.md).
+Flavor versions are designated by their exver prefix: `#flavor:upstream-semver:downstream-semver`. For more details on version formatting, see [Versions](/packaging/src/versions.md).
 
 ## Limitations
 


### PR DESCRIPTION
The link to exver.md in flavors.md is broken as that file no longer exists. Updated the link to point to versions.md which covers the same version formatting content.