### PR TITLE
Fix: start-cli init-key command name in cli-reference.md

### DIFF
--- a/start-os/src/cli-reference.md
+++ b/start-os/src/cli-reference.md
@@ -1049,7 +1049,7 @@ Display initialization logs. Same log options as `server logs`.
 
 Display initialization kernel logs. Same log options as `server logs`.
 
-### `start-cli init key`
+### `start-cli init-key`
 
 Create a new developer signing key.
 


### PR DESCRIPTION
The "Create a new developer signing key" command should be 'start-cli init-key' (hyphenated), not 'start-cli init key'. Confirmed against actual CLI behavior.