### PR TITLE
docs: Instructions pages for packagers and end users

### DIFF
--- a/packaging/src/SUMMARY.md
+++ b/packaging/src/SUMMARY.md
@@ -79,5 +79,6 @@
 - [Dependencies](dependencies.md)
 - [Makefile](makefile.md)
 - [Writing READMEs](writing-readmes.md)
+- [Writing Instructions](writing-instructions.md)
 - [Publishing](publishing.md)
 - [CLI Reference](cli.md)

--- a/packaging/src/manifest.md
+++ b/packaging/src/manifest.md
@@ -48,7 +48,6 @@ export const manifest = setupManifest({
   upstreamRepo: 'https://github.com/original/my-service',
   marketingUrl: 'https://example.com/',
   donationUrl: null,
-  docsUrls: ['https://docs.example.com/guides'],
   description: { short, long },
   volumes: ['main'],
   images: {
@@ -77,7 +76,6 @@ export const manifest = setupManifest({
 | `upstreamRepo`      | URL to the original project repository                 |
 | `marketingUrl`      | URL for the project's main website                     |
 | `donationUrl`       | Donation URL or `null`                                 |
-| `docsUrls`          | Array of URLs to **upstream** documentation            |
 | `description.short` | Locale object (see `manifest/i18n.ts`)                 |
 | `description.long`  | Locale object (see `manifest/i18n.ts`)                 |
 | `volumes`           | Storage volumes (usually `['main']`)                   |

--- a/packaging/src/writing-instructions.md
+++ b/packaging/src/writing-instructions.md
@@ -1,0 +1,113 @@
+# Writing Service Instructions
+
+`instructions.md` is a required file at the root of every StartOS package, alongside `README.md`. Its contents are packed into the s9pk archive and surfaced to the user under the **Instructions** tab on the service details page in StartOS, beneath the Dashboard.
+
+Instructions are **for the human running the service** — not for developers, not for AI assistants. They should orient that person to what the service is, walk them through getting it usefully running on StartOS, and point them at upstream documentation when they need to go deeper.
+
+## Instructions vs. README — they are not the same file
+
+It is tempting to treat `instructions.md` as a copy of the README. Resist this. The two files serve different audiences and answer different questions.
+
+| | README | instructions.md |
+|---|---|---|
+| **Audience** | Developers, AI assistants, contributors | End users running the service on StartOS |
+| **Question it answers** | "How does this package work, and how does it differ from running the upstream service directly?" | "I just installed this. What is it, and how do I actually use it?" |
+| **Tone** | Technical, structured, scannable for parsing | Practical, instructional, written in second person |
+| **Versions / image tags** | Avoided (manifest is source of truth) | Avoided for the same reason |
+| **Upstream behavior** | "Anything not listed here behaves as upstream documents" | Linked to at the bottom; never duplicated |
+| **Surfaced where** | The package repository on GitHub | Inside the StartOS UI, post-install |
+
+If your README is a reference manual, your instructions are a quick-start guide for a non-developer who just clicked Install.
+
+## What belongs in instructions
+
+A good `instructions.md` covers, roughly in this order:
+
+1. **What this service is** — one or two sentences. Assume the reader has heard of it but may not know exactly what it does. Link the project's home page or a recognizable description in the upstream docs.
+
+2. **What it gives you on StartOS** — the practical answer to "why did I just install this?" Keep it concrete: the interfaces it exposes, the data it manages, the experience the StartOS package adds on top of upstream.
+
+3. **Getting set up** — the smallest sequence of steps that takes a fresh install to a usable state. Use numbered lists. Reference real action names, real interfaces, and real screens that exist in the StartOS UI for this service. If setup requires a dependency, say so plainly: "Install Bitcoin Core first" rather than "satisfy the dependency."
+
+4. **Using the available features** — once the service is running, what can the user actually do with it? Describe the interfaces (web UI, RPC, etc.), the actions available from the StartOS sidebar, and any first-time tasks they will see prompted by the package.
+
+5. **Important limitations** — anything that will surprise the user. Things the upstream version does that this package does not. Features deliberately disabled. Restart-required settings. Performance constraints. Be honest; users prefer "this doesn't support X yet" over discovering it themselves.
+
+6. **External links** — at the end. Upstream documentation, project home page, support channels, anything else the user might want when they outgrow these instructions. Link to canonical, stable URLs (the project's docs site, not a specific GitHub commit).
+
+## What does not belong in instructions
+
+- **The full configuration reference.** Link to upstream for that.
+- **Version numbers and image tags.** They go stale every release; the manifest is the source of truth.
+- **Architectural detail about how the package is built.** That is the README's job.
+- **Reasons the package was structured a particular way.** Users do not care.
+- **Internal terminology from the StartOS codebase** ("ABI", "task", "manifest", "subcontainer"). Use the words a user sees in the UI.
+- **Secrets, default passwords, or API keys hard-coded into the markdown.** Generate those at install time and surface them via actions.
+
+## Style
+
+- Write in the second person. "You will see…", "When you click…", "Before you start, make sure…".
+- Prefer numbered lists for any multi-step procedure.
+- Use code blocks for commands the user might run, hostnames they might paste, or RPC calls — not for prose.
+- Keep paragraphs short. Many users will scan, not read.
+- Use H2 (`##`) for top-level sections; reserve H1 for the service name at the top of the file.
+- StartOS will render the markdown through the same pipeline as release notes and licenses, so standard CommonMark + GFM tables work; exotic HTML may not.
+
+## Suggested structure
+
+```markdown
+# [Service Name]
+
+[One- or two-sentence description of what the service is. Link the project home or a recognizable upstream description.]
+
+## What you get on StartOS
+
+[Concrete description of the StartOS experience: which interfaces are exposed, what data it manages, what the package adds on top of upstream.]
+
+## Getting set up
+
+1. [First concrete step the user should take after install.]
+2. [Second step…]
+3. [Until the service is in a usable state.]
+
+> If your service depends on another, list the dependency explicitly here and tell the user to install it first.
+
+## Using [Service Name]
+
+[Describe the day-to-day experience. Interfaces, actions, common workflows. One short subsection per major capability is fine.]
+
+### Web interface
+
+[How to reach it, what they will see first.]
+
+### Actions
+
+[Each StartOS action: what it does, when to run it.]
+
+### [Other capability]
+
+[…]
+
+## Limitations
+
+- [Anything that will surprise a user coming from upstream.]
+- [Features deliberately disabled or not yet supported.]
+- [Restart-required settings, performance caveats, etc.]
+
+## Learn more
+
+- [Project home](https://example.org)
+- [Upstream documentation](https://docs.example.org)
+- [Support / community](https://example.org/support)
+```
+
+## Pre-publish checklist
+
+- [ ] File exists at `instructions.md` at the package root (the build will fail otherwise).
+- [ ] Written for the user, not the developer — no internal SDK terminology.
+- [ ] Setup steps walk a fresh install to a usable state.
+- [ ] Every action and interface mentioned actually exists in the package.
+- [ ] No hard-coded version numbers, image tags, or secrets.
+- [ ] Limitations section is honest about what the package cannot do.
+- [ ] Upstream links go to canonical, stable URLs.
+- [ ] Renders cleanly in the StartOS Instructions tab on a real install.

--- a/start-os/src/SUMMARY.md
+++ b/start-os/src/SUMMARY.md
@@ -23,6 +23,7 @@
 - [Sideloading](sideloading.md)
 - [Flavors](flavors.md)
 - [Interfaces](interfaces.md)
+- [Instructions](instructions.md)
 - [Actions](actions.md)
 - [Health Checks](health-checks.md)
 - [Tasks](tasks.md)

--- a/start-os/src/instructions.md
+++ b/start-os/src/instructions.md
@@ -1,0 +1,28 @@
+# Instructions
+
+Every service installed on StartOS ships with an **Instructions** page, accessible from a tab on the service details page sidebar (just below Dashboard). Instructions are written by the package's developer for you, the person actually running the service — they explain what the service is, walk you through getting it set up on StartOS, and tell you how to use it once it's running.
+
+## When to Read Them
+
+The first time you install a service is the most useful moment to open Instructions. Many services have a small number of setup steps that need to happen before they're truly usable — creating an admin password, importing a config, installing a dependency, registering a domain, and so on. Instructions are where the developer documents that path, in the order you should follow it.
+
+After initial setup, Instructions remain a quick reference for day-to-day use: which interfaces the service exposes, which actions in the sidebar do what, and any limitations you should know about.
+
+## What's In Them
+
+A well-written Instructions page typically covers:
+
+- **What the service is** — a short description of what it does.
+- **What you get on StartOS** — how this packaged version looks and behaves on your server.
+- **Getting set up** — numbered steps to take the service from a fresh install to a usable state.
+- **Using the service** — the interfaces, actions, and tasks you'll work with.
+- **Limitations** — anything that behaves differently from the upstream version of the software.
+- **External links** — the project's home page, upstream documentation, and support channels for when you need to go deeper.
+
+## Instructions vs. README
+
+A package's GitHub README is a technical document for developers and contributors — how the package is built, how it differs internally from the upstream service. Instructions, by contrast, are written for **you**: practical, step-by-step, focused on what to click and what to expect. If you ever want both perspectives, the README lives in the package's repository, linked from the **About** tab.
+
+## Missing or Empty Instructions
+
+If a service was installed before its developer added an Instructions page (or hasn't published instructions yet), the tab will display a notice that no instructions are provided. In that case, check the service's **About** tab for links to the package repository and upstream docs, or wait for an update that includes instructions.


### PR DESCRIPTION
## Summary

Companion to [start-os#3224](https://github.com/Start9Labs/start-os/pull/3224), which makes `instructions.md` a required user-facing file at the root of every package and renders it under a new **Instructions** tab on the service details page.

- **packaging book** gets `writing-instructions.md` — a developer guide for what belongs in `instructions.md` (and what doesn't). It explicitly contrasts `instructions.md` with the README to keep the two files from drifting into duplicates: README is for developers/contributors and explains how the package works internally; instructions are for end users and explain how to actually use the service after install.
- **start-os book** gets `instructions.md` — a user-facing page explaining what the new Instructions tab is, when to read it, what's typically inside, and how it differs from the package's README. Slotted into the Services section of the sidebar between Interfaces and Actions.
- **packaging/manifest.md** drops `docsUrls` from the example snippet and the Required Fields table. start-os#3224 removes the field from the manifest schema since `instructions.md` is now where upstream documentation links belong.

Both new pages are linked into their respective `SUMMARY.md`. `./build.sh` builds clean across all four books.

## Test plan

- [x] `./build.sh` succeeds for all books
- [x] New pages appear in each book's sidebar
- [x] `docsUrls` no longer appears anywhere in the source (built `docs/` regenerated by `./build.sh`)
- [ ] Manual: render-check the two new pages in dev with `./serve.sh`