### PR TITLE
docs(start-os): fix false claim about scheduled/optional backup encryption

### DIFF
--- a/start-os/src/backup-create.md
+++ b/start-os/src/backup-create.md
@@ -1,6 +1,6 @@
 # Creating Backups
 
-Back up your server's data to a physical drive or a network folder. Backups can be encrypted and scheduled to run automatically.
+Back up your server's data to a physical drive or a network folder.
 
 > [!IMPORTANT]
 > Creating backups is an essential responsibility of self-hosting. If you do not make backups, you _will_ eventually lose your data.


### PR DESCRIPTION
## Summary

- `backup-create.md` claimed backups "can be encrypted and scheduled to run automatically." Both halves are wrong: backups are *always* encrypted, and there is no way to schedule them from the web UI. Deleted the sentence; the remaining intro line ("Back up your server's data to a physical drive or a network folder.") still satisfies the per-page intro-prose requirement.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)