### PR TITLE
docs: move service interfaces to dedicated Interfaces tab

### DIFF
--- a/packaging/src/writing-instructions.md
+++ b/packaging/src/writing-instructions.md
@@ -1,6 +1,6 @@
 # Writing Service Instructions
 
-`instructions.md` is a required file at the root of every StartOS package, alongside `README.md`. Its contents are packed into the s9pk archive and surfaced to the user under the **Instructions** tab on the service details page in StartOS, beneath the Dashboard.
+`instructions.md` is a required file at the root of every StartOS package, alongside `README.md`. Its contents are packed into the s9pk archive and surfaced to the user under the **Instructions** tab on the service details page in StartOS.
 
 Instructions are **for the human running the service** — not for developers, not for AI assistants. They pick up where the marketplace listing left off: by the time someone reads this tab they have seen the short and long description and clicked Install, so don't reintroduce the service. Orient them to what it does *on StartOS*, walk them through getting it usefully running, and point them at upstream documentation when they need to go deeper.
 

--- a/start-os/src/instructions.md
+++ b/start-os/src/instructions.md
@@ -1,6 +1,6 @@
 # Instructions
 
-Every service installed on StartOS ships with an **Instructions** page, accessible from a tab on the service details page sidebar (just below Dashboard). Instructions are written by the package's developer for you, the person actually running the service — they explain what the service is, walk you through getting it set up on StartOS, and tell you how to use it once it's running.
+Every service installed on StartOS ships with an **Instructions** page, accessible from the **Instructions** tab in the service details page sidebar. Instructions are written by the package's developer for you, the person actually running the service — they explain what the service is, walk you through getting it set up on StartOS, and tell you how to use it once it's running.
 
 ## When to Read Them
 

--- a/start-os/src/interfaces.md
+++ b/start-os/src/interfaces.md
@@ -1,6 +1,6 @@
 # Interfaces
 
-A service interface is a network endpoint exposed by a service running on your server. Every installed service exposes one or more interfaces, each serving a different purpose. The service interfaces for a given service are listed on its dashboard under the **Service Interfaces** heading.
+A service interface is a network endpoint exposed by a service running on your server. Every installed service exposes one or more interfaces, each serving a different purpose. The service interfaces for a given service are listed under the **Interfaces** tab in the sidebar of its service details page.
 
 ## Interface Types
 
@@ -12,7 +12,7 @@ A service interface is a network endpoint exposed by a service running on your s
 
 ## Viewing Interface Addresses
 
-Clicking a service interface from the dashboard opens its **addresses page**. This page shows all the ways that interface can be reached, organized by [gateway](gateways.md).
+Open the **Interfaces** tab to see every interface the service exposes. Each interface expands to reveal its **addresses** — all the ways that interface can be reached, organized by [gateway](gateways.md). When a service exposes only one interface, it is expanded by default.
 
 ### Gateway Tables
 
@@ -41,7 +41,7 @@ You can add domains to a gateway table by clicking "Add Domain" on the gateway a
 
 ### Tor Onion Addresses
 
-If the [Tor](tor.md) service is installed and running, a **Tor** table also appears on the addresses page. Tor functions like a gateway but is managed as a marketplace service rather than a system gateway.
+If the [Tor](tor.md) service is installed and running, a **Tor** table also appears among the interface's addresses. Tor functions like a gateway but is managed as a marketplace service rather than a system gateway.
 
 The Tor table is empty by default. To add onion addresses:
 
@@ -53,4 +53,4 @@ The Tor table is empty by default. To add onion addresses:
 
 1. Optionally, you can upload a private key to use a [vanity `.onion` address](https://community.torproject.org/onion-services/advanced/vanity-addresses/).
 
-1. To view your onion addresses, go to **Actions > View Onion Addresses**. They will also appear in the Tor table on each service interface's addresses page.
+1. To view your onion addresses, go to **Actions > View Onion Addresses**. They will also appear in the Tor table for each service interface.

--- a/start-os/src/public-ip.md
+++ b/start-os/src/public-ip.md
@@ -10,7 +10,7 @@ For hosting websites or APIs that people access in a browser, use a [public doma
 
 ## Enable Public IP Access
 
-1. On the service interface's addresses page, locate the gateway you want to use.
+1. In the **Interfaces** tab, expand the service interface and locate the gateway you want to use.
 
 1. Find its public IPv4 address and toggle it on.
 

--- a/start-os/src/tor.md
+++ b/start-os/src/tor.md
@@ -12,11 +12,11 @@ Tor is not included in StartOS by default. To use Tor, you must install the **To
 
 ## Creating and Deleting Onion Services
 
-Once Tor is installed, a **Tor** addresses table appears on each service's [interface](interfaces.md) addresses page.
+Once Tor is installed, a **Tor** addresses table appears for each service [interface](interfaces.md), under the **Interfaces** tab.
 
 1. Navigate to the service you want to expose over Tor.
 
-1. Open the interface's addresses page.
+1. Open the **Interfaces** tab and expand the interface.
 
 1. In the Tor table, click **Add Onion Service** to create a `.onion` address for that interface.
 


### PR DESCRIPTION
## Summary

Updates the docs to reflect [start-os#3276](https://github.com/Start9Labs/start-os/pull/3276), which promotes service interfaces from a dashboard card to a dedicated **Interfaces** sidebar tab, removes the per-interface "addresses page" route in favor of an expandable accordion within that tab, and adds an **Actions & Config** tab that shifts the sidebar order.

- `start-os/src/interfaces.md` — interfaces now live under the **Interfaces** tab; rewrote "Viewing Interface Addresses" for the expand-to-reveal accordion (single interface expanded by default); fixed two "addresses page" references.
- `start-os/src/tor.md` — onion-service steps now open the **Interfaces** tab and expand the interface.
- `start-os/src/public-ip.md` — same navigation correction for enabling public IP.
- `start-os/src/instructions.md` — dropped the now-incorrect "(just below Dashboard)" position.
- `packaging/src/writing-instructions.md` — dropped the matching stale "beneath the Dashboard" claim.

The SDK `mdnsResolvable` helper from the PR is already documented in the SDK `CHANGELOG.md` and isn't surfaced in the packaging book, so no packaging-API doc change was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)