### PR TITLE
docs(packaging): guide smaller models packaging prebuilt images

### DIFF
--- a/packaging/AGENTS.md
+++ b/packaging/AGENTS.md
@@ -84,6 +84,10 @@ Understand these before writing any code (full detail on the pages above):
 
 The full rules are in `start-docs/packaging/src/workflow.md`; this is the digest.
 
+- **Verify facts; don't assert from memory.** Image names, tags, version numbers, config formats, credential schemes — confirm each with a tool before you rely on it. "I know that X" is a cue to check X, not to write it down. Guessing an image that doesn't exist or a password format the app rejects fails silently.
+- **Compiling is not working.** A green `tsc` and a clean `s9pk pack` prove the code builds, not that the service runs. Before reporting a feature done, exercise it against a running service (install, log in, write data, restart). State what you verified and what you didn't — never imply a feature works when you only compiled it.
+- **Don't fabricate; verify or flag.** Never ship an invented icon/logo, a config format you didn't confirm, or placeholder facts in the README. Fetch the real thing, or leave it and flag the gap in `TODO.md`.
+- **Search before declaring impossible.** Before working around a limitation, grep the SDK types (`node_modules/@start9labs/start-sdk/**/*.d.ts`) and existing packages. "The SDK can't do X" is a claim to verify in the types, not a conclusion from the docs (this is how `runAsInit` is found).
 - **Keep `README.md` and `instructions.md` in sync.** After any change to user-visible behavior, review both and update them in the same change. Content rules: `writing-readmes.md`, `writing-instructions.md`.
 - **Iterate with a dirty tree; commit once.** The `-modified` pack-hash suffix is informational — don't commit between test attempts. One clean commit when the package works; `git reset --soft HEAD~N` collapses accumulated fixups.
 - **Pre-existing errors are still errors.** A red `tsc`, test, or pack step means the package doesn't pass, even if unrelated to your change. Fix it or flag it; never report green when a check was red.
@@ -91,4 +95,4 @@ The full rules are in `start-docs/packaging/src/workflow.md`; this is the digest
 
 ## Starting a new package
 
-A package scaffolded by `start-cli s9pk init-package` is a barebones hello-world clone with a `TODO.md` checklist. **Work `TODO.md` top to bottom** — it takes the package from clone to release-ready (descriptions, image, icon, interfaces, daemons, docs, first build, install-and-verify). Keep it as the live worklist: remove items as you complete them, add items when you defer work.
+**Scaffold first — run `start-cli s9pk init-package "<Name>"`. Do not hand-assemble a package by copying files out of another one.** Scaffolding produces a barebones hello-world clone with a `TODO.md` checklist. **Then work `TODO.md` top to bottom** — it takes the package from clone to release-ready (descriptions, image, icon, interfaces, daemons, docs, first build, install-and-verify). Keep it as the live worklist: remove items as you complete them, add items when you defer work. Wrapping an existing upstream Docker image? Read `recipe-prebuilt-image.md` first.

--- a/packaging/src/SUMMARY.md
+++ b/packaging/src/SUMMARY.md
@@ -17,6 +17,7 @@
 ## Configuration
 
 - [Set Up a Basic Service](recipe-basic-service.md)
+- [Package a Prebuilt Docker Image](recipe-prebuilt-image.md)
 - [Create Configuration Actions](recipe-config-actions.md)
 - [Generate Config Files](recipe-config-files.md)
 - [Pass Config via Environment Variables](recipe-env-vars.md)

--- a/packaging/src/main.md
+++ b/packaging/src/main.md
@@ -248,7 +248,7 @@ Some images bundle their own init system or process supervisor — `s6-overlay` 
 - The image uses `s6-overlay` (any `linuxserver/*` image), `tini`, `dumb-init`, or `supervisord` as its entrypoint
 - The daemon starts but its supervisor immediately crashes complaining it is not PID 1
 
-Leave it off (the default) for images whose entrypoint is the application binary itself. If you suspect this option doesn't exist, grep the installed SDK types — `runAsInit` is declared on the `exec` options in `node_modules/@start9labs/start-sdk/**/Daemons.d.ts`. See [Package a Prebuilt Docker Image](recipe-prebuilt-image.md) for the full prebuilt-image workflow.
+Leave it off (the default) for images whose entrypoint is the application binary itself. (`runAsInit` is declared on the `exec` options in `Daemons.d.ts` — like many SDK options, it's easier to find by grepping the types than by searching the docs; see [Search the SDK before deciding something is impossible](workflow.md#search-the-sdk-before-deciding-something-is-impossible).) See [Package a Prebuilt Docker Image](recipe-prebuilt-image.md) for the full prebuilt-image workflow.
 
 ## Environment Variables
 

--- a/packaging/src/main.md
+++ b/packaging/src/main.md
@@ -227,6 +227,29 @@ Use a custom command array when you need to bypass the entrypoint entirely:
 })
 ```
 
+### Running the Entrypoint as PID 1 (`runAsInit`)
+
+Some images bundle their own init system or process supervisor — `s6-overlay` (used by **every** `linuxserver/*` image), `tini`, `dumb-init`, or `supervisord` — and that supervisor expects to run as **PID 1**. In a StartOS subcontainer the daemon command is not PID 1 by default, so such a supervisor aborts on startup (s6 logs `s6-overlay-suexec: fatal: can only run as pid 1`). Set `runAsInit: true` on the `exec` to make the command the container's init process:
+
+```typescript
+.addDaemon('primary', {
+  subcontainer: appSub,
+  exec: {
+    command: sdk.useEntrypoint(),
+    runAsInit: true, // image bundles s6-overlay / tini / supervisord, which must be PID 1
+    env: { PUID: '1000', PGID: '1000', TZ: 'Etc/UTC' },
+  },
+  // ...
+})
+```
+
+**When to use `runAsInit: true`:**
+
+- The image uses `s6-overlay` (any `linuxserver/*` image), `tini`, `dumb-init`, or `supervisord` as its entrypoint
+- The daemon starts but its supervisor immediately crashes complaining it is not PID 1
+
+Leave it off (the default) for images whose entrypoint is the application binary itself. If you suspect this option doesn't exist, grep the installed SDK types — `runAsInit` is declared on the `exec` options in `node_modules/@start9labs/start-sdk/**/Daemons.d.ts`. See [Package a Prebuilt Docker Image](recipe-prebuilt-image.md) for the full prebuilt-image workflow.
+
 ## Environment Variables
 
 Pass environment variables to a daemon or oneshot via the `env` option on `exec`:

--- a/packaging/src/recipe-admin-credentials.md
+++ b/packaging/src/recipe-admin-credentials.md
@@ -14,6 +14,9 @@ The shape gives you:
 
 When the upstream service requires the password to be applied via CLI or API (rather than read from the store at startup), wrap the work in `sdk.SubContainer.withTemp()` inside the action handler and run the upstream command before returning — see the [Reset a Password](recipe-reset-password.md) recipe for the temp-subcontainer shape.
 
+> [!WARNING]
+> Do not hand-write a credential into the app's config file in a format you have not confirmed. Many apps store web passwords as **salted PBKDF2 or bcrypt** values with app-specific framing, not as a bare hash you can compute and drop into a config key — and writing the wrong format does not error, it silently rejects every login. Prefer applying the password through the app's **own** CLI/API (the temp-subcontainer shape above). If you must write the config directly, first confirm the exact on-disk format by setting a password through the app once and reading back what it wrote. Either way, **verify a real login succeeds before shipping** — a credential flow that has never been logged into is not done.
+
 **Reference:** [Initialization](init.md) · [Tasks](tasks.md) · [Actions](actions.md)
 
 ## Examples

--- a/packaging/src/recipe-basic-service.md
+++ b/packaging/src/recipe-basic-service.md
@@ -6,6 +6,8 @@ A minimal StartOS service: one container, one web UI, one health check, one back
 
 Define a daemon in `setupMain()` with one subcontainer, mount a volume, and add a `checkPortListening` health check. Define a single HTTP interface in `setupInterfaces()` using `MultiHost.of()` and `createInterface()`. Define backups with `sdk.Backups.ofVolumes()` to back up the data volume.
 
+> **Wrapping an upstream Docker image** (a `linuxserver/*` or official `org/app` image) rather than building your own? Start here for the shape, then read [Package a Prebuilt Docker Image](recipe-prebuilt-image.md) for the image-specific concerns — verifying the image, mounting every data path, init systems, and credentials.
+
 **Reference:** [Main](main.md) · [Interfaces](interfaces.md)
 
 ## Examples

--- a/packaging/src/recipe-prebuilt-image.md
+++ b/packaging/src/recipe-prebuilt-image.md
@@ -1,0 +1,102 @@
+# Package a Prebuilt Docker Image
+
+The most common packaging task is wrapping an existing upstream Docker image — `linuxserver/*`, an official `org/app` image, a community image — rather than building your own from a `Dockerfile`. It looks simple, and the happy path is. But the same handful of mistakes sink these packages over and over: the image name is guessed instead of verified, only one of the image's data paths gets mounted, non-UI ports are forgotten, an image with its own init system crashes because it isn't PID 1, and credentials are "set" by hand-editing a config format that was never confirmed. This recipe is the checklist that keeps those from happening.
+
+This page assumes the service shape from [Set Up a Basic Service](recipe-basic-service.md) — daemon, interface, health check, backup — and covers only what's different when you don't control the image. If you're starting a brand-new package, scaffold first (`start-cli s9pk init-package "My Service"`) and work its `TODO.md` top to bottom; this recipe expands the "replace the hello-world image" line of that checklist.
+
+## Solution
+
+Build the basic-service skeleton first, then apply these prebuilt-image concerns:
+
+1. **Verify the image before you pin it.** Do not guess a `org/name`. Confirm the exact repository exists, the tag you want is published, and it ships the architectures StartOS needs (`x86_64` and `aarch64` at minimum). Pin `images.<id>.source.dockerTag` to that confirmed `image:tag` and set `arch` accordingly. See [Verify the image](#verify-the-image) below.
+2. **Mount _every_ path the image persists.** Inspect the image (or its docs) for all data and config paths — there is usually more than one (e.g. a config dir _and_ a downloads/data dir). Mount each one, or that data lands on the container's ephemeral filesystem and is lost on every restart. See [Mount all data paths](#mount-all-data-paths).
+3. **Expose every port the service needs — not just the web UI.** A torrent client needs its peer port; a mail server needs SMTP/IMAP; a database needs its wire port. Bind the UI in [`setupInterfaces()`](interfaces.md) and add the others via [Expose Multiple Interfaces](recipe-multi-interface.md). A constant like `peerPort` that is declared but never bound is a tell that a port was forgotten.
+4. **Run the image's entrypoint, and make it PID 1 if it has its own init system.** Use `sdk.useEntrypoint()` to keep the upstream startup behavior. If the image bundles an init/supervisor — `s6-overlay` (every `linuxserver/*` image), `tini`, `dumb-init`, `supervisord` — set `runAsInit: true` on the daemon's `exec`, or the supervisor crashes because it is not PID 1. See [Images with their own init system](#images-with-their-own-init-system).
+5. **Pass the env vars the image expects.** Many community images are configured through environment variables — `linuxserver/*` images read `PUID`, `PGID`, and `TZ` to drop privileges and set ownership; others take `APP_*` settings. Set them via `exec.env`. See [Pass Config via Environment Variables](recipe-env-vars.md).
+6. **Apply credentials through the app's own mechanism — never a hand-written hash.** If the service needs an admin password, follow [Prompt User to Create Admin Credentials](recipe-admin-credentials.md). Do **not** invent the on-disk credential format; see [Credentials](#credentials).
+7. **Verify by installing, not by compiling.** A clean `tsc` and a successful `s9pk pack` prove the code type-checks — not that the service runs. Install on a StartOS box, open the UI, and exercise the actual feature (log in, add data) before calling it done. See [Development Workflow — Verify against reality](workflow.md#verify-against-reality-not-against-tsc).
+
+**Reference:** [Set Up a Basic Service](recipe-basic-service.md) (the underlying skeleton) · [Main](main.md) · [Manifest](manifest.md) · [Interfaces](interfaces.md)
+
+## Verify the image
+
+Before writing `dockerTag`, confirm three things from the registry — never from memory:
+
+- **The repository exists** at the name you think it does. Image names are easy to misremember (`qbittorrentserver/qbittorrent` does not exist; `linuxserver/qbittorrent` does). Pulling, or fetching the registry's tags endpoint, tells you for sure.
+- **The tag is published.** `latest` almost always exists; a specific `X.Y.Z` may not, or may be spelled differently (`5.2.1`, `v5.2.1`, `version-5.2.1`).
+- **It is multi-arch.** Inspect the manifest list for `amd64`/`x86_64` and `arm64`/`aarch64`. An image that only ships `amd64` cannot target StartOS's ARM hardware.
+
+```bash
+# List published tags (Docker Hub library/community image):
+curl -s "https://hub.docker.com/v2/repositories/linuxserver/qbittorrent/tags?page_size=25" \
+  | jq -r '.results[].name'
+
+# Confirm the tag is multi-arch:
+docker manifest inspect linuxserver/qbittorrent:5.2.1 \
+  | jq -r '.manifests[].platform.architecture'
+```
+
+```typescript
+images: {
+  qbittorrent: {
+    source: { dockerTag: 'linuxserver/qbittorrent:5.2.1' },
+    arch: ['x86_64', 'aarch64'],
+  },
+},
+```
+
+## Mount all data paths
+
+Enumerate the paths the image writes to and persists — its documentation lists them, or you can run the image and watch where it creates files. Mount each path that must survive a restart. Missing a data mount does not produce an error; it silently discards that data on every restart, which is far worse.
+
+```typescript
+subcontainer: await sdk.SubContainer.of(
+  effects,
+  { imageId: 'qbittorrent' },
+  sdk.Mounts.of()
+    .mountVolume({ volumeId: 'main', subpath: 'config',    mountpoint: '/config',    readonly: false })
+    .mountVolume({ volumeId: 'main', subpath: 'downloads', mountpoint: '/downloads', readonly: false }),
+  'qbittorrent-sub',
+),
+```
+
+> A torrent client that mounts `/config` but not `/downloads` "works" in every quick test and loses every download the moment the service restarts. Map the data path, not just the config path.
+
+## Images with their own init system
+
+`linuxserver/*` images (and anything built on `s6-overlay`, `tini`, `dumb-init`, or `supervisord`) expect their init system to run as **PID 1**. In a StartOS subcontainer the daemon command is not PID 1 by default, so the supervisor aborts (s6 logs `s6-overlay-suexec: fatal: can only run as pid 1`). Set `runAsInit: true`:
+
+```typescript
+exec: {
+  command: sdk.useEntrypoint(),
+  runAsInit: true, // image bundles s6-overlay, which must be PID 1
+  env: { PUID: '1000', PGID: '1000', TZ: 'Etc/UTC' },
+},
+```
+
+See [Main — `runAsInit`](main.md#running-the-entrypoint-as-pid-1-runasinit) for the full description. If an image's bundled init system genuinely cannot be made to work, the fallback is to build your own image from a `Dockerfile` and invoke the binary directly — but reach for `runAsInit` first; it resolves the common case. Before concluding an SDK capability you need doesn't exist, grep the installed SDK types (`node_modules/@start9labs/start-sdk/**/*.d.ts`) — `runAsInit` is one of several options that live there.
+
+## Credentials
+
+If the service has a web login, follow [Prompt User to Create Admin Credentials](recipe-admin-credentials.md): a `setupOnInit` watcher surfaces a critical task, and a `setAdminPassword` action generates, stores, and returns the credential.
+
+The trap specific to prebuilt images is **how** the password reaches the application. Do not assume the on-disk format. Many apps store the web password as a salted **PBKDF2** or **bcrypt** value with app-specific framing — not as a bare hash you can compute and drop into a config key. Writing the wrong format does not error; the app silently rejects the login. So:
+
+- Apply the credential through the app's **own** API or CLI (run it in `sdk.SubContainer.withTemp()` from the action — see [Reset a Password](recipe-reset-password.md)), **or**
+- If you must write the config directly, first **confirm the real format** by setting a password through the app once and reading back exactly what it wrote.
+
+Either way, **verify a real login succeeds** before shipping. A credential flow that has never been logged into is not done.
+
+## Examples
+
+See `startos/main.ts` and `startos/manifest/index.ts` in packages that wrap prebuilt images: [ollama](https://github.com/Start9Labs/ollama-startos), [jellyfin](https://github.com/Start9Labs/jellyfin-startos), [vaultwarden](https://github.com/Start9Labs/vaultwarden-startos), [immich](https://github.com/Start9Labs/immich-startos), [home-assistant](https://github.com/Start9Labs/home-assistant-startos).
+
+## Checklist
+
+- [ ] Image repository, tag, and arches confirmed from the registry (not from memory)
+- [ ] Every persisted path mounted (config **and** data)
+- [ ] Every required port exposed (UI **and** non-UI)
+- [ ] `sdk.useEntrypoint()` used; `runAsInit: true` if the image has its own init system
+- [ ] Required env vars set (`PUID`/`PGID`/`TZ` for `linuxserver/*`, etc.)
+- [ ] Credentials applied via the app's own mechanism; a real login verified
+- [ ] Installed on a StartOS box and the feature exercised — not just `tsc` green

--- a/packaging/src/recipe-prebuilt-image.md
+++ b/packaging/src/recipe-prebuilt-image.md
@@ -74,7 +74,7 @@ exec: {
 },
 ```
 
-See [Main — `runAsInit`](main.md#running-the-entrypoint-as-pid-1-runasinit) for the full description. If an image's bundled init system genuinely cannot be made to work, the fallback is to build your own image from a `Dockerfile` and invoke the binary directly — but reach for `runAsInit` first; it resolves the common case. Before concluding an SDK capability you need doesn't exist, grep the installed SDK types (`node_modules/@start9labs/start-sdk/**/*.d.ts`) — `runAsInit` is one of several options that live there.
+See [Main — `runAsInit`](main.md#running-the-entrypoint-as-pid-1-runasinit) for the full description. If an image's bundled init system genuinely cannot be made to work, the fallback is to build your own image from a `Dockerfile` and invoke the binary directly — but reach for `runAsInit` first; it resolves the common case.
 
 ## Credentials
 
@@ -86,6 +86,11 @@ The trap specific to prebuilt images is **how** the password reaches the applica
 - If you must write the config directly, first **confirm the real format** by setting a password through the app once and reading back exactly what it wrote.
 
 Either way, **verify a real login succeeds** before shipping. A credential flow that has never been logged into is not done.
+
+Two more traps surface only when you actually test the login:
+
+- **Reverse-proxy guards.** StartOS fronts the service with its own proxy, so the request the app sees has a different `Host`/`Origin`/port than it served. Apps with host-header or CSRF validation (qBittorrent's `WebUI\HostHeaderValidation`, many others) reject every proxied request — often with a `401` that looks like a bad password but isn't. Check the app's log for the real reason, and disable the guard the app provides for running behind a proxy. Watch the inverse too: a "trust localhost" auth bypass can let proxy-local requests skip the password entirely — disable it.
+- **Config you write while the app runs can be clobbered.** Many apps rewrite their whole config file on shutdown from in-memory state. If your action edits the config and then restarts the service, the shutdown flush overwrites your edit before the new instance reads it. Write config-file changes from `setupMain` *before* the daemon launches (the previous instance has already stopped and flushed), or apply them through the running app's API instead.
 
 ## Examples
 

--- a/packaging/src/recipes.md
+++ b/packaging/src/recipes.md
@@ -4,11 +4,14 @@ This is the primary entry point for StartOS service packaging — for both you a
 
 If you're using [Claude Code](https://claude.com/claude-code) (recommended), point your agent at the recipe for your task and let it follow the reference and package links from there.
 
+> **Starting a brand-new package?** Scaffold it first with `start-cli s9pk init-package "My Service"`, then work the generated `TODO.md` from top to bottom — don't hand-assemble files by copying another package. If you're wrapping an existing upstream Docker image (the common case), read [Package a Prebuilt Docker Image](recipe-prebuilt-image.md) before you start.
+
 ## Configuration
 
 | Recipe | Description |
 |--------|-------------|
 | [Set Up a Basic Service](recipe-basic-service.md) | Minimal single-container service with a web UI, health check, and backup |
+| [Package a Prebuilt Docker Image](recipe-prebuilt-image.md) | Wrap an upstream `linuxserver/*` or official image — verify the image, mount every data path, expose all ports, handle init systems and credentials |
 | [Create Configuration Actions](recipe-config-actions.md) | Let users configure your service through actions with input forms |
 | [Generate Config Files](recipe-config-files.md) | Produce YAML, TOML, INI, JSON, or ENV files from user settings using FileModel |
 | [Pass Config via Environment Variables](recipe-env-vars.md) | Configure your service through environment variables in the daemon definition |

--- a/packaging/src/workflow.md
+++ b/packaging/src/workflow.md
@@ -47,7 +47,11 @@ When you don't know a fact, find it; don't invent it and move on. The failure mo
 - **Upstream internals** — config-file formats, credential hashing schemes, file paths. Read them from the app or its docs, or apply them through the app's own CLI/API. Hand-writing a format you assumed (e.g. a bare hash where the app expects salted PBKDF2) fails silently.
 - **Brand assets.** Never ship an invented `icon.svg` or logo. Fetch the real asset from upstream, or leave the placeholder and flag that it still needs the real icon.
 
-When you can't verify something, surface it as an open question or a `TODO.md` item — don't paper over it with confident prose in the README. Relatedly, before concluding the SDK can't do something you need, grep the installed types (`node_modules/@start9labs/start-sdk/**/*.d.ts`); the option often exists.
+When you can't verify something, surface it as an open question or a `TODO.md` item — don't paper over it with confident prose in the README.
+
+## Search the SDK before deciding something is impossible
+
+Before concluding the SDK can't do what you need — or working around a limitation you've assumed — grep the installed type definitions: `node_modules/@start9labs/start-sdk/**/*.d.ts`. The SDK exposes far more than the recipes show, and the option you want is often a field on a type you're already using (this is how `runAsInit` is found, for example). "The SDK doesn't support X" is a claim to verify in the types, not a conclusion to reach from the docs alone. If it genuinely isn't there, say so and explain the workaround — don't silently route around a capability that exists.
 
 ## Don't create unnecessary version files
 

--- a/packaging/src/workflow.md
+++ b/packaging/src/workflow.md
@@ -29,6 +29,26 @@ See [Writing READMEs](./writing-readmes.md) and [Writing Instructions](./writing
 
 If `tsc`, a test, or the pack step fails — even on something unrelated to your change — the package does not pass. "Pre-existing" is not a pass condition; it is a signal that nobody has fixed the problem yet. Either fix it, or stop and flag it explicitly. Never report a run as green when any check was red.
 
+## Verify against reality, not against `tsc`
+
+A clean `tsc` and a successful `start-cli s9pk pack` prove the code type-checks and the package builds. They prove **nothing** about whether the service runs, the web UI loads, logins work, or data persists. Type-checking a credential flow that has never accepted a login, or a daemon that mounts the wrong path, passes just as green as one that works.
+
+Before reporting a feature as done, exercise it against a running service:
+
+- **Install on a StartOS box** (or run the image directly) and confirm the daemon stays up — not just that it starts.
+- **Use the actual feature.** If you wired up admin credentials, log in with them. If you mounted a data volume, write data and restart to confirm it survives. If you exposed a port, connect to it.
+- **A feature you have only compiled is unverified.** Say so plainly — "builds clean; not yet installed/tested" — rather than implying it works.
+
+## Don't fabricate — verify or flag
+
+When you don't know a fact, find it; don't invent it and move on. The failure mode to avoid is stating a guess with the confidence of a checked fact. Three places this bites hardest:
+
+- **Image names and tags.** Confirm the repository and tag exist in the registry before pinning `dockerTag` — don't guess `org/name` from memory. (See [Package a Prebuilt Docker Image](recipe-prebuilt-image.md).)
+- **Upstream internals** — config-file formats, credential hashing schemes, file paths. Read them from the app or its docs, or apply them through the app's own CLI/API. Hand-writing a format you assumed (e.g. a bare hash where the app expects salted PBKDF2) fails silently.
+- **Brand assets.** Never ship an invented `icon.svg` or logo. Fetch the real asset from upstream, or leave the placeholder and flag that it still needs the real icon.
+
+When you can't verify something, surface it as an open question or a `TODO.md` item — don't paper over it with confident prose in the README. Relatedly, before concluding the SDK can't do something you need, grep the installed types (`node_modules/@start9labs/start-sdk/**/*.d.ts`); the option often exists.
+
 ## Don't create unnecessary version files
 
 Most version bumps edit `startos/versions/current.ts` in place — change the `version` and `releaseNotes`, leave `index.ts` and the filename alone. A new file is only spun off when the bump carries a migration. See [Versions — When to Create a New Version File](./versions.md#when-to-create-a-new-version-file) for the rule, and [Release Notes](./versions.md#release-notes) for how to write the notes that accompany a bump.


### PR DESCRIPTION
## Why

These changes come out of reviewing a real packaging session where a **smaller / lower-effort model** (a 27B local model) was asked to package qBittorrent. It produced a package that *compiled and packed cleanly* but needed **seven user corrections** and still shipped real defects. Almost everything it got wrong is already documented somewhere in the guide — it just never found or followed the right page. So this PR targets **discoverability and prescriptiveness** at the exact points where a small model goes off the rails, plus one genuine doc gap.

### Observed failures (and the gap each exposes)
- **Guessed a Docker image** (`qbittorrentserver/qbittorrent`) that doesn't exist → no "verify the image before pinning" guidance.
- **Mounted only `/config`, never `/downloads`** → downloads silently lost on restart; no "mount *every* data path" emphasis.
- **Never exposed the BitTorrent peer port** (declared `peerPort`, never bound it) → torrenting crippled.
- **Declared the s6-overlay PID-1 problem near-impossible** → **`runAsInit` was undocumented** anywhere in the guide.
- **Hallucinated the credential format** (wrote a bare SHA-256 to `WebUI\Password=`; qBittorrent uses salted PBKDF2) and **never once logged in successfully**, yet reported the auth flow as working → no "verify the real format / verify a real login" rule, and `tsc`-green was treated as done.
- **Fabricated a fake icon**, hand-assembled all 36 files instead of scaffolding, and committed 8 times mid-iteration.

## Changes

- **New recipe — [Package a Prebuilt Docker Image](packaging/src/recipe-prebuilt-image.md).** The most common packaging task gets its own checklist-style page: verify image (exists / tag / arch), mount every data path, expose all ports, `useEntrypoint()` + `runAsInit` for images with their own init system, `PUID`/`PGID`/`TZ`, credentials via the app's own mechanism, and verify-by-install. Registered in `recipes.md` and `SUMMARY.md`. Defers the basic service shape to **Set Up a Basic Service** (which now cross-links here) to avoid overlap.
- **`main.md`:** documents **`runAsInit`** for the first time, with the s6-overlay / `linuxserver/*` PID-1 use case.
- **`workflow.md`:** adds *"Verify against reality, not against `tsc`"* (install and exercise the feature; a compiled feature is unverified) and *"Don't fabricate — verify or flag"* (image names, upstream config/credential formats, brand assets; and grep the SDK `.d.ts` before declaring something impossible).
- **`recipe-admin-credentials.md`:** a warning to apply the password through the app's own API/CLI and verify a real login, rather than hand-writing an unconfirmed hash format.

## Testing

mdBook isn't installed in this environment, so the book wasn't built locally. All new internal links and heading anchors were checked by hand against existing files. A maintainer should run `./serve.sh` to confirm the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)