### PR TITLE
docs: correct gmail smtp port and fields to match start-os

### DIFF
--- a/start-os/src/smtp.md
+++ b/start-os/src/smtp.md
@@ -17,21 +17,25 @@ The guides below are for using Gmail, Amazon SES, or Proton Mail for SMTP, but y
 
 1. Enable 2-Step verification if not already.
 
-1. Under "App Passwords" (bottom), add a new App Password.
+1. Go to the App Passwords page: https://myaccount.google.com/apppasswords. Google no longer links to it from the 2-Step Verification page, so navigate there directly.
 
 1. Choose a name for the new App Password. You may call it anything, such as "SMTP", then click "Create".
 
 1. A random 16-character password will be created and shown to you. This is your app password. Save it somewhere secure, such as your Vaultwarden password manager, then click "Done".
 
-1. Now you can use this SMTP account for any service that has the capability to send an email. The table below shows all the details you may need:
+1. In StartOS, go to **System > SMTP**, select **Gmail** as the provider, and enter the values below. Choosing Gmail pre-fills the host and defaults to TLS on port 465.
 
-   | Parameter  | Value                          |
-   | ---------- | ------------------------------ |
-   | Host       | smtp.gmail.com                 |
-   | Port       | 587                            |
-   | Encryption | TLS                            |
-   | Username   | your-username@gmail.com        |
-   | Password   | your App Password (from above) |
+   | Parameter           | Value                          |
+   | ------------------- | ------------------------------ |
+   | Host                | smtp.gmail.com                 |
+   | Connection Security | TLS                            |
+   | Port                | 465                            |
+   | From Address        | your-username@gmail.com        |
+   | Username            | your-username@gmail.com        |
+   | Password            | your App Password (from above) |
+
+   > [!NOTE]
+   > Selecting Gmail pre-fills and locks the **Host**, and choosing **TLS** locks the **Port** at 465. To use STARTTLS instead, set **Connection Security** to **STARTTLS** and the **Port** becomes **587**. The **From Address** may optionally include a display name, e.g. `Your Name <your-username@gmail.com>`.
 
 {{#endtab}}
 


### PR DESCRIPTION
## Summary

The Gmail SMTP guide didn't match the actual StartOS **System > SMTP** form, and one detail of Gmail's own app-password flow was stale.

- **Port:** was `587` paired with `TLS` — an impossible combination. Selecting Gmail defaults to **TLS**, which pins the port to **465** in StartOS (`587` is only reachable under **STARTTLS**). Corrected to `465`.
- **Field name:** renamed the chart's "Encryption" row to **Connection Security** to match the form's actual label (TLS / STARTTLS).
- **Missing field:** added the required **From Address** row, which the chart omitted entirely.
- **App password step:** Google no longer surfaces App Passwords at the bottom of the 2-Step Verification page — pointed the step directly at `myaccount.google.com/apppasswords`.
- Added a note documenting the locked Host/Port behavior, the STARTTLS/587 alternative, and the optional display-name form of the From Address.

Verified against `core/start-os` (`sdk/base/lib/actions/input/inputSpecConstants.ts` and the System > SMTP page) and against Gmail's current published SMTP settings.

Source `start-os/src/smtp.md` only; the rendered `docs/start-os/smtp.html` regenerates on build.