### PR TITLE
docs(packaging): release notes should summarize upstream highlights + link

### DIFF
--- a/packaging/src/versions.md
+++ b/packaging/src/versions.md
@@ -165,7 +165,7 @@ When making changes to the StartOS wrapper without upstream changes:
 
 ## Release Notes
 
-`releaseNotes` renders as markdown in the StartOS UI. **Say something useful about the release — never just name the version bump.** A bare `Bumps Ghost → 6.38.0.` tells the user nothing about what actually changed. Read the upstream release notes / changelog for the bumped range, pull out the highlights that matter to a user (notable features, important fixes, security patches, breaking changes / required actions), and summarize them. Then link to the complete upstream release notes or changelog so the user can read the full detail. If the upstream release is genuinely trivial (e.g. a dependency-only patch), say that explicitly rather than padding — but still say *something*.
+`releaseNotes` renders as markdown in the StartOS UI. **Describe what changed in the release.** Read the upstream release notes / changelog for the bumped range, pull out the highlights that matter to a user (notable features, important fixes, security patches, breaking changes / required actions), and summarize them. Then link to the complete upstream release notes or changelog so the user can read the full detail. If the upstream release is genuinely trivial (e.g. a dependency-only patch), say that explicitly.
 
 **Match the length to the content.** A small release is a sentence or two; a larger one earns bullets, and bold section headers (`**Features**`, `**Fixes**`, `**Internal**`) once it spans more than one category. Localize prose and headers in every locale; don't leave them in English.
 

--- a/packaging/src/versions.md
+++ b/packaging/src/versions.md
@@ -165,33 +165,47 @@ When making changes to the StartOS wrapper without upstream changes:
 
 ## Release Notes
 
-`releaseNotes` renders as markdown in the StartOS UI. **Match the length to the content — if it fits on one line, write one line.** A single-change release doesn't need bullets, headers, or a backtick template literal. Reach for bullets when there are several items in one category; add bold section headers (`**Bumps**`, `**Features**`, `**Fixes**`, `**Internal**`) only when the release spans more than one category. Localize the headers in every locale; don't leave them in English.
+`releaseNotes` renders as markdown in the StartOS UI. **Say something useful about the release — never just name the version bump.** A bare `Bumps Ghost → 6.38.0.` tells the user nothing about what actually changed. Read the upstream release notes / changelog for the bumped range, pull out the highlights that matter to a user (notable features, important fixes, security patches, breaking changes / required actions), and summarize them. Then link to the complete upstream release notes or changelog so the user can read the full detail. If the upstream release is genuinely trivial (e.g. a dependency-only patch), say that explicitly rather than padding — but still say *something*.
+
+**Match the length to the content.** A small release is a sentence or two; a larger one earns bullets, and bold section headers (`**Features**`, `**Fixes**`, `**Internal**`) once it spans more than one category. Localize prose and headers in every locale; don't leave them in English.
 
 ```ts
-// One change: plain string.
-releaseNotes: { en_US: 'Bumps Ghost → 6.38.0.', /* …other locales */ },
-
-// Several items, one category: bullets, no header.
+// Small release: a sentence naming the bump + the key change, then the link.
 releaseNotes: {
-  en_US: `- Ghost → 6.38.0
-- MySQL → 8.4.9`,
+  en_US: `Updated Ghost to 6.38.0. Fixes a crash when restoring from backup and patches a moderate XSS vulnerability in the editor. Full notes: https://github.com/TryGhost/Ghost/releases/tag/v6.38.0`,
+  // …other locales
+},
+
+// Larger release: highlights as bullets, then the link.
+releaseNotes: {
+  en_US: `Updated Ghost to 6.38.0.
+
+- New: scheduled newsletter sends
+- Fix: crash on backup restore
+- Security: patched editor XSS
+
+[Full release notes](https://github.com/TryGhost/Ghost/releases/tag/v6.38.0)`,
   // …
 },
 
-// Multiple categories: headers + bullets.
+// Multiple categories spanning the wrapper and upstream: headers + bullets.
 releaseNotes: {
-  en_US: `**Bumps**
+  en_US: `Updated Ghost to 6.38.0 and bumped the start-sdk.
 
-- Ghost → 6.38.0
+**Features**
+
+- New: scheduled newsletter sends
 
 **Fixes**
 
-- Crash on backup restart.`,
+- Crash on backup restart
+
+[Full upstream release notes](https://github.com/TryGhost/Ghost/releases/tag/v6.38.0)`,
   // …
 },
 ```
 
-Use a template literal (backticks) only when the note actually spans multiple lines, and never indent its content lines.
+Use a template literal (backticks) only when the note actually spans multiple lines, and never indent its content lines. If you genuinely can't find upstream notes, link to the upstream commit/tag comparison instead.
 
 ## Migrations
 


### PR DESCRIPTION
## What

Rewrites the **Release Notes** section of `packaging/src/versions.md` so the guidance and examples push authors toward informative notes instead of a bare `Bumps Ghost → 6.38.0.`

- Lead instruction is now "say something useful — never just name the version bump": read the upstream changelog, summarize the user-facing highlights, and link the full upstream release notes / changelog.
- Examples updated to show a one-bump note that names the bump + key changes + link, a bulleted highlights note with a link, and a multi-category note with headers and an upstream link.
- Keeps the "match length to content" rule and the trivial-release escape hatch (say it's trivial rather than padding; link a commit/tag comparison if no notes exist).

## Why

Companion to Start9Labs/helix#28, which updates the update-monitor prompt with the same guidance. @matthill asked that both the monitor prompt and the docs example show release notes that actually describe what changed.

Related: Start9Labs/helix#28