### PR TITLE
docs(backup): note StartOSBackups → StartOSBackupsV2 format change

### DIFF
--- a/start-os/src/backup-create.md
+++ b/start-os/src/backup-create.md
@@ -27,6 +27,11 @@ Back up your server's data to a physical drive or a network folder.
 
 1. Backups taken from a specific system architecture (x86, ARM, RISC-V) are backed up for just that architecture. If restored to another architecture, they will likely need to be reinstalled to run efficiently.
 
+1. The backup format changed. New backups are written to a `StartOSBackupsV2` folder on the target. If the target still contains an older `StartOSBackups` folder from a previous version, StartOS warns you when you select that drive — and once the new backup completes successfully, you can delete the old `StartOSBackups` folder (do _not_ delete `StartOSBackupsV2`) to reclaim space.
+
+   > [!WARNING]
+   > If the old `StartOSBackups` folder is larger than the free space remaining on the drive, the new backup will not fit and StartOS will not start it. Delete the old `StartOSBackups` folder first, or choose another drive.
+
 ## Best Practices
 
 Even with proper backups the risk of data corruption is always non-zero. Therefore it is recommended to take additional care when backing up highly valuable or irreplaceable data like a lightning node:


### PR DESCRIPTION
Companion to start-os#3324.

Adds a note to the **Creating Backups** page explaining the backup format change:
- new backups go to a `StartOSBackupsV2` folder
- if an old `StartOSBackups` folder is present, StartOS warns on drive selection; delete it (not `StartOSBackupsV2`) after a successful backup
- if the old folder is larger than the free space remaining, the backup is refused — delete it first or use another drive

Code PR: https://github.com/Start9Labs/start-os/pull/3324